### PR TITLE
fix: apply add_messages reducer to State.messages

### DIFF
--- a/src/core/state.py
+++ b/src/core/state.py
@@ -18,7 +18,7 @@ class State(BaseModel):
     )
 
     # === Context Layer ===
-    messages: list[BaseMessage] = Field(
+    messages: Annotated[list[BaseMessage], add_messages] = Field(
         default_factory=list,
         description="Sequence of messages exchanged in the workflow"
     )


### PR DESCRIPTION
## Problem

`State.messages` was declared as plain `list[BaseMessage]`:

```python
messages: list[BaseMessage] = Field(
    default_factory=list,
    description="Sequence of messages exchanged in the workflow"
)
```

LangGraph requires `Annotated[list[BaseMessage], add_messages]` to register the `add_messages` reducer. Without it, each node invocation that returns new messages **replaces** the entire list instead of appending to it — conversation history is wiped on every turn.

`add_messages` was already imported on line 5 but never applied, causing the bug described in #30.

## Fix

```python
messages: Annotated[list[BaseMessage], add_messages] = Field(
    default_factory=list,
    description="Sequence of messages exchanged in the workflow"
)
```

Fixes #30